### PR TITLE
Fix errors not printed in interactive exercises

### DIFF
--- a/lib/python3/try_hook.rb
+++ b/lib/python3/try_hook.rb
@@ -31,8 +31,8 @@ python
   def to_structured_results(_file, result, status)
     /#{query_separator}
 ?(.*)
-#{goal_separator}
-?(.*)
+(?:#{goal_separator}
+?(.*))?
 /m =~ result
 
     {

--- a/lib/python3/try_hook.rb
+++ b/lib/python3/try_hook.rb
@@ -29,15 +29,14 @@ python
   end
 
   def to_structured_results(_file, result, status)
-    /#{query_separator}
-?(.*)
-(?:#{goal_separator}
-?(.*))?
-/m =~ result
+    result_match = result[/#{query_separator}
+\K.*?(?=(#{goal_separator})|\z)/m]&.rstrip
+    goal_match = result[/#{goal_separator}
+\K.*\z/m]&.rstrip
 
     {
-        query: to_query_result($1, status),
-        goal: $2,
+        query: to_query_result(result_match, status),
+        goal: goal_match,
         status: status
     }
   end

--- a/spec/common/integration_shared_examples.rb
+++ b/spec/common/integration_shared_examples.rb
@@ -46,6 +46,15 @@ class TestFoo(unittest.TestCase):
     expect(response).to eq(status: :passed, result: "False\n")
   end
 
+  it 'answers a valid hash when query produces an error due to extra' do
+    response = bridge.run_query!(extra: "def suma_sin_sentido():\n  return numero + 8",
+                                 content: '',
+                                 query: 'suma_sin_sentido()')
+
+    expect(response[:result]).to include "name 'numero' is not defined"
+    expect(response[:status]).to eq :failed
+  end
+
   it 'answers a valid hash when submission has syntax errors' do
     response = bridge.
         run_tests!(test: '

--- a/spec/python3/integration_spec.rb
+++ b/spec/python3/integration_spec.rb
@@ -72,7 +72,7 @@ class TestFoo(unittest.TestCase):
         cookie: [],
         goal: { kind: 'last_query_equals', value: '4 < 9' })
     expect(response).to eq(status: :failed,
-                           query_result: {result: "SyntaxError: Missing parentheses in call to 'print'. Did you mean print(4)?", status: :failed},
+                           query_result: {result: "  File \"<input>\", line 1\n     print 4\n           ^\n SyntaxError: Missing parentheses in call to 'print'. Did you mean print(4)?", status: :failed},
                            result: "query should be '4 < 9' but was 'print 4'")
   end
 

--- a/spec/python3/integration_spec.rb
+++ b/spec/python3/integration_spec.rb
@@ -56,7 +56,28 @@ class TestFoo(unittest.TestCase):
                            result: '')
   end
 
-  it 'answers a valid hash when submitting an interactive query that passes' do
+  it 'answers a valid hash when submitting an interactive query that fails' do
+    response = bridge.run_try!(
+        query: '4 >= 9',
+        cookie: [],
+        goal: { kind: 'last_query_equals', value: '4 < 9' })
+    expect(response).to eq(status: :failed,
+                           query_result: {result: "False", status: :passed},
+                           result: "query should be '4 < 9' but was '4 >= 9'")
+  end
+
+  it 'answers a valid hash when submitting an interactive query that fails and raises an error' do
+    response = bridge.run_try!(
+        query: 'print 4',
+        cookie: [],
+        goal: { kind: 'last_query_equals', value: '4 < 9' })
+    expect(response).to eq(status: :failed,
+                           query_result: {result: "SyntaxError: Missing parentheses in call to 'print'. Did you mean print(4)?", status: :failed},
+                           result: "query should be '4 < 9' but was 'print 4'")
+  end
+
+
+  it 'answers a valid hash when submitting an interactive query with regexps that passes' do
     response = bridge.run_try!(
         query: '5 in [1, 2, 4]',
         cookie: [
@@ -75,7 +96,7 @@ class TestFoo(unittest.TestCase):
                            result: "goal was met successfully")
   end
 
-  it 'answers a valid hash when submitting an interactive query that fails' do
+  it 'answers a valid hash when submitting an interactive query with regexps that fails' do
     response = bridge.run_try!(
         query: '3 in [1, 2, 3]',
         cookie: [
@@ -93,7 +114,6 @@ class TestFoo(unittest.TestCase):
                            query_result: {result: "True", status: :passed},
                            result: 'All the required queries must be executed')
   end
-
 
   it 'exposes python version' do
     expect(bridge.info['language']).to include('version' => '3.7.3')

--- a/spec/python3/query_hook_spec.rb
+++ b/spec/python3/query_hook_spec.rb
@@ -10,6 +10,13 @@ describe Python3QueryHook do
   context 'errors if an exception was thrown in query in 2-style' do
     let(:request) { struct query: 'raise Exception, "bar"' }
     it { expect(result[1]).to eq :errored }
+    it { expect(result[0]).to include 'SyntaxError: invalid syntax' }
+  end
+
+  context 'failed if an exception is thrown' do
+    let(:request) { struct query: 'raise Exception("bar")' }
+    it { expect(result[1]).to eq :failed }
+    it { expect(result[0]).to eq "  File \"<input>\", line 1, in <module>\n Exception: bar\n\n" }
   end
 
   context 'passes when standalone query is valid and returns a string.' do
@@ -36,5 +43,17 @@ describe Python3QueryHook do
   context 'fails when query is an incomplete print' do
     let(:request) { struct query: 'print("hello"' }
     it { expect(result).to eq ["SyntaxError: unexpected EOF while parsing", :errored] }
+  end
+
+  context 'fails when query is an old-style print' do
+    let(:request) { struct query: 'print 4' }
+    it { expect(result).to eq ["print 4\n           ^\n SyntaxError: Missing parentheses in call to 'print'. Did you mean print(4)?", :errored] }
+  end
+
+
+  context 'fails when query calls errored extra' do
+    let(:request) { struct extra: "def f():\n  return something", query: 'f()' }
+    it { expect(result[0]).to include "name 'something' is not defined" }
+    it { expect(result[1]).to eq :failed }
   end
 end

--- a/spec/python3/try_hook_spec.rb
+++ b/spec/python3/try_hook_spec.rb
@@ -9,29 +9,43 @@ describe Python3TryHook do
   context 'try with last_query_equals goal' do
     let(:goal) { { kind: 'last_query_equals', value: '"something"' } }
 
-    context 'and query that matches' do
+    context 'when query matches' do
       let(:request) { struct query: '"something"', goal: goal }
       it { expect(result[1]).to eq :passed }
       it { expect(result[2][:result]).to eq "'something'" }
     end
 
-    context 'and query that does not match' do
+    context 'when query does not match' do
       let(:request) { struct query: '"somethingElse"', goal: goal }
       it { expect(result[1]).to eq :failed }
       it { expect(result[2][:result]).to eq "'somethingElse'" }
+    end
+
+    context 'when query fails' do
+      let(:request) { struct query: '0 / 0', goal: goal }
+      it { expect(result[1]).to eq :failed }
+      it { expect(result[2][:status]).to eq :failed }
+      it { expect(result[2][:result]).to eq "  File \"<input>\", line 1, in <module>\n ZeroDivisionError: division by zero" }
+    end
+
+    context 'when query errors' do
+      let(:request) { struct query: 'print 4', goal: goal }
+      it { expect(result[1]).to eq :failed }
+      it { expect(result[2][:status]).to eq :errored }
+      it { expect(result[2][:result]).to include "SyntaxError: Missing parentheses in call to 'print'. Did you mean print(4)?" }
     end
   end
 
   context 'try with last_query_matches goal' do
     let(:goal) { { kind: 'last_query_matches', regexp: /print(.*)/ } }
 
-    context 'and query that matches' do
+    context 'when query matches' do
       let(:request) { struct query: 'print(3)', goal: goal }
       it { expect(result[1]).to eq :passed }
       it { expect(result[2][:result]).to eq '3' }
     end
 
-    context 'and query that does not match' do
+    context 'when query does not match' do
       let(:request) { struct query: 'abs(2)', goal: goal }
       it { expect(result[1]).to eq :failed }
       it { expect(result[2][:result]).to eq '2' }
@@ -41,13 +55,13 @@ describe Python3TryHook do
   context 'try with last_query_matches goal, with string' do
     let(:goal) { { kind: 'last_query_matches', regexp: '^print(.*)' } }
 
-    context 'and query that matches' do
+    context 'when query matches' do
       let(:request) { struct query: 'print(3)', goal: goal }
       it { expect(result[1]).to eq :passed }
       it { expect(result[2][:result]).to eq '3' }
     end
 
-    context 'and query that does not match' do
+    context 'when query does not match' do
       let(:request) { struct query: 'abs(2)', goal: goal }
       it { expect(result[1]).to eq :failed }
       it { expect(result[2][:result]).to eq '2' }
@@ -57,13 +71,13 @@ describe Python3TryHook do
   context 'try with last_query_matches goal, with =' do
     let(:goal) { { kind: 'last_query_matches', regexp: '^4\W+!=\W+5' } }
 
-    context 'and query that matches' do
+    context 'when query matches' do
       let(:request) { struct query: '4  !=  5  ', goal: goal }
       it { expect(result[1]).to eq :passed }
       it { expect(result[2][:result]).to eq 'True' }
     end
 
-    context 'and query that does not match' do
+    context 'when query does not match' do
       let(:request) { struct query: '4 != 4   ', goal: goal }
       it { expect(result[1]).to eq :failed }
       it { expect(result[2][:result]).to eq 'False' }
@@ -73,13 +87,13 @@ describe Python3TryHook do
   context 'try with last_query_matches goal, with <' do
     let(:goal) { { kind: 'last_query_matches', regexp: '^4\W+<\W+5' } }
 
-    context 'and query that matches' do
+    context 'when query matches' do
       let(:request) { struct query: '4  <  5  ', goal: goal }
       it { expect(result[1]).to eq :passed }
       it { expect(result[2][:result]).to eq 'True' }
     end
 
-    context 'and query that does not match' do
+    context 'when query does not match' do
       let(:request) { struct query: '4 < 4   ', goal: goal }
       it { expect(result[1]).to eq :failed }
       it { expect(result[2][:result]).to eq 'False' }
@@ -89,16 +103,16 @@ describe Python3TryHook do
   context 'try with last_query_matches goal, with prefix spaces' do
     let(:goal) { { kind: 'last_query_matches', regexp: '^4\W+<\W+5' } }
 
-    context 'and query that matches' do
+    context 'when query matches' do
       let(:request) { struct query: '    4  <  5', goal: goal }
       it { expect(result[1]).to eq :failed }
-      it { expect(result[2]).to eq result: nil, status: :failed }
+      it { expect(result[2]).to eq result: "  File \"<input>\", line 1\n     4  <  5\n     ^\n IndentationError: unexpected indent", status: :failed }
     end
 
-    context 'and query that does not match' do
+    context 'when query does not match' do
       let(:request) { struct query: '    4 < 4', goal: goal }
       it { expect(result[1]).to eq :failed }
-      it { expect(result[2]).to eq result: nil, status: :failed }
+      it { expect(result[2]).to eq result: "  File \"<input>\", line 1\n     4 < 4\n     ^\n IndentationError: unexpected indent", status: :failed }
     end
   end
 
@@ -121,13 +135,13 @@ describe Python3TryHook do
   context 'try with query_fails goal' do
     let(:goal) { { kind: 'query_fails', query: 'my_var' } }
 
-    context 'and query that makes said query pass' do
+    context 'when query makes said query pass' do
       let(:request) { struct query: 'my_var = 2;', goal: goal }
       it { expect(result[1]).to eq :failed }
       it { expect(result[2][:result]).to eq '' }
     end
 
-    context 'and query that does not make said query pass' do
+    context 'when query does not make said query pass' do
       let(:request) { struct query: '', goal: goal }
       it { expect(result[1]).to eq :passed }
       it { expect(result[2][:result]).to eq '' }
@@ -137,13 +151,13 @@ describe Python3TryHook do
   context 'try with query_passes goal' do
     let(:goal) { { kind: 'query_passes', query: 'my_var' } }
 
-    context 'and query that makes said query pass' do
+    context 'when query makes said query pass' do
       let(:request) { struct query: 'my_var = 2;', goal: goal }
       it { expect(result[1]).to eq :passed }
       it { expect(result[2][:result]).to eq '' }
     end
 
-    context 'and query that does not make said query pass' do
+    context 'when query does not make said query pass' do
       let(:request) { struct query: '', goal: goal }
       it { expect(result[1]).to eq :failed }
       it { expect(result[2][:result]).to eq '' }
@@ -153,13 +167,13 @@ describe Python3TryHook do
   context 'try with query_outputs goal' do
     let(:goal) { { kind: 'query_outputs', query: 'my_var', output: '55' } }
 
-    context 'and query that generates said output' do
+    context 'when query generates said output' do
       let(:request) { struct query: 'my_var = 55;', goal: goal }
       it { expect(result[1]).to eq :passed }
       it { expect(result[2][:result]).to eq '' }
     end
 
-    context 'and query that does not generate said output' do
+    context 'when query does not generate said output' do
       let(:request) { struct query: 'my_var = 28', goal: goal }
       it { expect(result[1]).to eq :failed }
       it { expect(result[2][:result]).to eq '' }
@@ -169,16 +183,16 @@ describe Python3TryHook do
   context 'try with last_query_passes goal' do
     let(:goal) { { kind: 'last_query_passes' } }
 
-    context 'and query that passes' do
+    context 'when query passes' do
       let(:request) { struct query: '123', goal: goal }
       it { expect(result[1]).to eq :passed }
       it { expect(result[2][:result]).to eq '123' }
     end
 
-    context 'and query that fails' do
+    context 'when query fails' do
       let(:request) { struct query: 'asdasd', goal: goal }
       it { expect(result[1]).to eq :failed }
-      pending { expect(result[2]).to eq result: "Reference error", status: :failed }
+      it { expect(result[2]).to eq result: "  File \"<input>\", line 1, in <module>\n NameError: name 'asdasd' is not defined", status: :failed }
     end
   end
 end

--- a/spec/python3/try_hook_spec.rb
+++ b/spec/python3/try_hook_spec.rb
@@ -31,7 +31,7 @@ describe Python3TryHook do
     context 'when query errors' do
       let(:request) { struct query: 'print 4', goal: goal }
       it { expect(result[1]).to eq :failed }
-      it { expect(result[2][:status]).to eq :errored }
+      it { expect(result[2][:status]).to eq :failed }
       it { expect(result[2][:result]).to include "SyntaxError: Missing parentheses in call to 'print'. Did you mean print(4)?" }
     end
   end


### PR DESCRIPTION
# :dart: Goal

To show errors when they arise in try hook

# :soon: Future work

Actually mark SyntaxError and IndentationError as `:errored`