### PR TITLE
Fix handle errored results at try hook

### DIFF
--- a/lib/python3/try_hook.rb
+++ b/lib/python3/try_hook.rb
@@ -19,6 +19,13 @@ python
 
   delegate :tempfile_extension, to: :query_hook
   delegate :command_line, to: :query_hook
+  delegate :error_patterns, to: :query_hook
+
+  def post_process_file(_file, result, status)
+    pattern = error_patterns.find { |it| it.matches? result, status }
+    result, status = pattern ? pattern.transform(result, status) : [result, status]
+    super _file, result, status
+  end
 
   def query_separator
     '!!!MUMUKI-QUERY-START!!!'

--- a/lib/python3/try_hook.rb
+++ b/lib/python3/try_hook.rb
@@ -1,6 +1,5 @@
 class Python3TryHook < Mumukit::Templates::TryHook
   isolated true
-  attr_reader :query_hook
 
   def initialize(config = nil)
     super config
@@ -9,19 +8,19 @@ class Python3TryHook < Mumukit::Templates::TryHook
 
   def compile_file_content(r)
     <<python
-#{query_hook.compile_file_header(r)}
+#{@query_hook.compile_file_header(r)}
 print("#{query_separator}");
-#{query_hook.compile_query(r.query, '')}
+#{@query_hook.compile_query(r.query, '')}
 print("#{goal_separator}");
-#{query_hook.compile_query(r.goal.indifferent_get(:query) || 'None', '')}
+#{@query_hook.compile_query(r.goal.indifferent_get(:query) || 'None', '')}
 python
   end
 
-  delegate :tempfile_extension, to: :query_hook
-  delegate :command_line, to: :query_hook
+  delegate :tempfile_extension, to: :@query_hook
+  delegate :command_line, to: :@query_hook
 
   def post_process_file(file, result, status)
-    super file, *query_hook.post_process_file(file, result, status)
+    super file, *@query_hook.post_process_file(file, result, status)
   end
 
   def query_separator

--- a/lib/python3/try_hook.rb
+++ b/lib/python3/try_hook.rb
@@ -19,12 +19,9 @@ python
 
   delegate :tempfile_extension, to: :query_hook
   delegate :command_line, to: :query_hook
-  delegate :error_patterns, to: :query_hook
 
-  def post_process_file(_file, result, status)
-    pattern = error_patterns.find { |it| it.matches? result, status }
-    result, status = pattern ? pattern.transform(result, status) : [result, status]
-    super _file, result, status
+  def post_process_file(file, result, status)
+    super file, *query_hook.post_process_file(file, result, status)
   end
 
   def query_separator

--- a/spec/python3/integration_spec.rb
+++ b/spec/python3/integration_spec.rb
@@ -72,7 +72,7 @@ class TestFoo(unittest.TestCase):
         cookie: [],
         goal: { kind: 'last_query_equals', value: '4 < 9' })
     expect(response).to eq(status: :failed,
-                           query_result: {result: "  File \"<input>\", line 1\n     print 4\n           ^\n SyntaxError: Missing parentheses in call to 'print'. Did you mean print(4)?", status: :failed},
+                           query_result: {result: "  File \"<input>\", line 1\n     print 4\n           ^\n SyntaxError: Missing parentheses in call to 'print'. Did you mean print(4)?", status: :errored},
                            result: "query should be '4 < 9' but was 'print 4'")
   end
 

--- a/spec/python3/try_hook_spec.rb
+++ b/spec/python3/try_hook_spec.rb
@@ -31,7 +31,7 @@ describe Python3TryHook do
     context 'when query errors' do
       let(:request) { struct query: 'print 4', goal: goal }
       it { expect(result[1]).to eq :failed }
-      it { expect(result[2][:status]).to eq :failed }
+      it { expect(result[2][:status]).to eq :errored }
       it { expect(result[2][:result]).to include "SyntaxError: Missing parentheses in call to 'print'. Did you mean print(4)?" }
     end
   end
@@ -106,13 +106,15 @@ describe Python3TryHook do
     context 'when query matches' do
       let(:request) { struct query: '    4  <  5', goal: goal }
       it { expect(result[1]).to eq :failed }
-      it { expect(result[2]).to eq result: "  File \"<input>\", line 1\n     4  <  5\n     ^\n IndentationError: unexpected indent", status: :failed }
+      it { expect(result[2][:result]).to eq "  File \"<input>\", line 1\n     4  <  5\n     ^\n IndentationError: unexpected indent" }
+      it { expect(result[2][:status]).to eq :errored }
     end
 
     context 'when query does not match' do
       let(:request) { struct query: '    4 < 4', goal: goal }
       it { expect(result[1]).to eq :failed }
-      it { expect(result[2]).to eq result: "  File \"<input>\", line 1\n     4 < 4\n     ^\n IndentationError: unexpected indent", status: :failed }
+      it { expect(result[2][:result]).to eq "  File \"<input>\", line 1\n     4 < 4\n     ^\n IndentationError: unexpected indent" }
+      it { expect(result[2][:status]).to eq :errored }
     end
   end
 
@@ -192,7 +194,15 @@ describe Python3TryHook do
     context 'when query fails' do
       let(:request) { struct query: 'asdasd', goal: goal }
       it { expect(result[1]).to eq :failed }
-      it { expect(result[2]).to eq result: "  File \"<input>\", line 1, in <module>\n NameError: name 'asdasd' is not defined", status: :failed }
+      it { expect(result[2][:result]).to eq "  File \"<input>\", line 1, in <module>\n NameError: name 'asdasd' is not defined" }
+      it { expect(result[2][:status]).to eq :failed }
+    end
+
+    context 'when query errors' do
+      let(:request) { struct query: 'asdasd 5', goal: goal }
+      it { expect(result[1]).to eq :failed }
+      it { expect(result[2][:result]).to eq "  File \"<input>\", line 1\n     asdasd 5\n            ^\n SyntaxError: invalid syntax" }
+      it { expect(result[2][:status]).to eq :errored }
     end
   end
 end


### PR DESCRIPTION
# :dart: Goal

To handle `SyntaxError`  and `IndentationError` as `errored` in try hook. 

# :memo: Details

Before this PR, after the aforementioned exceptions, the console breaks and no new output was produced. With this fix, such queries are marked as `errored` and thus they are filtered from cookie.  

# :camera_flash: Screenshots

## Before

![image](https://user-images.githubusercontent.com/677436/110890335-9800df80-82ce-11eb-98ef-f429bc13b394.png)


## After

![image](https://user-images.githubusercontent.com/677436/110890003-f7122480-82cd-11eb-9817-535d69765f5c.png)

# :eyes: See also 

#26 