### PR TITLE
Feature add pandas support

### DIFF
--- a/lib/base/metadata_hook.rb
+++ b/lib/base/metadata_hook.rb
@@ -16,8 +16,13 @@ class Test(unittest.TestCase):
   def test_description_example(self):
     self.assertTrue(True)
 python
-     }}
+     },
+     libraries: libraries,
+    }.compact
   end
 
   required :version
+
+  def libraries
+  end
 end

--- a/lib/python2_runner.rb
+++ b/lib/python2_runner.rb
@@ -3,7 +3,7 @@ require_relative './base'
 def reload_python2_runner!
   Mumukit.runner_name = 'python'
   Mumukit.configure do |config|
-    config.docker_image = 'mumuki/mumuki-python2-worker:0.1'
+    config.docker_image = 'mumuki/mumuki-python2-worker:0.2'
     # comment type should be Mumukit::Directives::CommentType::Ruby, but it is
     # Mumukit::Directives::CommentType::Cpp for backward compatibility
     config.stateful = true

--- a/lib/python3/metadata_hook.rb
+++ b/lib/python3/metadata_hook.rb
@@ -2,5 +2,8 @@ class Python3MetadataHook < BasePythonMetadataHook
   def version
     '3.7.3'
   end
-end
 
+  def libraries
+    {pandas: '1.3.3'}
+  end
+end

--- a/lib/python3_runner.rb
+++ b/lib/python3_runner.rb
@@ -3,7 +3,7 @@ require_relative './base'
 def reload_python3_runner!
   Mumukit.runner_name = 'python3'
   Mumukit.configure do |config|
-    config.docker_image = 'mumuki/mumuki-python3-worker:0.1'
+    config.docker_image = 'mumuki/mumuki-python3-worker:0.2'
     config.comment_type = Mumukit::Directives::CommentType::Ruby
     config.structured = true
     config.stateful = true

--- a/lib/python3_runner.rb
+++ b/lib/python3_runner.rb
@@ -3,7 +3,7 @@ require_relative './base'
 def reload_python3_runner!
   Mumukit.runner_name = 'python3'
   Mumukit.configure do |config|
-    config.docker_image = 'mumuki/mumuki-python3-worker:0.2'
+    config.docker_image = 'mumuki/mumuki-python3-worker:0.3'
     config.comment_type = Mumukit::Directives::CommentType::Ruby
     config.structured = true
     config.stateful = true

--- a/spec/python3/integration_spec.rb
+++ b/spec/python3/integration_spec.rb
@@ -122,4 +122,8 @@ class TestFoo(unittest.TestCase):
   it 'exposes ruby comment type' do
     expect(bridge.info['comment_type']).to eq('ruby')
   end
+
+  it 'exposes pandas version' do
+    expect(bridge.info['libraries']['pandas']).to eq('1.3.3')
+  end
 end

--- a/spec/python3/integration_spec.rb
+++ b/spec/python3/integration_spec.rb
@@ -56,6 +56,22 @@ class TestFoo(unittest.TestCase):
                            result: '')
   end
 
+  it 'answers a valid hash when extra imports pandas and query uses a DataFrame' do
+    response = bridge.run_query!(extra: 'import pandas as pd',
+                                 content: '',
+                                 query: 'pd.DataFrame([{"name": "mary", "surname": "doe"}, {"name": "john", "surname": "doe"}])')
+    expect(response).to eq(status: :passed, result: "   name surname\n0  mary     doe\n1  john     doe\n")
+  end
+
+
+  it 'answers a valid hash when importing and using pandas in query' do
+    response = bridge.run_query!(extra: '',
+                                 content: '',
+                                 query: 'pd.DataFrame([{"name": "mary", "surname": "doe"}, {"name": "john", "surname": "doe"}])',
+                                 cookie: ['import pandas as pd'])
+    expect(response).to eq(status: :passed, result: "   name surname\n0  mary     doe\n1  john     doe\n")
+  end
+
   it 'answers a valid hash when submitting an interactive query that fails' do
     response = bridge.run_try!(
         query: '4 >= 9',

--- a/worker2/Dockerfile
+++ b/worker2/Dockerfile
@@ -1,9 +1,9 @@
 FROM python:2.7.16-alpine
 MAINTAINER Franco Leonardo Bulgarelli
 
-RUN wget https://github.com/xmlrunner/unittest-xml-reporting/archive/master.zip && \
-    unzip master.zip && \
-    cd unittest-xml-reporting-master && \
+RUN wget https://github.com/xmlrunner/unittest-xml-reporting/archive/2.5.1.zip && \
+    unzip 2.5.1.zip && \
+    cd unittest-xml-reporting-2.5.1 && \
     python setup.py install
 
 COPY rununittest /bin/rununittest

--- a/worker3/Dockerfile
+++ b/worker3/Dockerfile
@@ -6,5 +6,8 @@ RUN wget https://github.com/xmlrunner/unittest-xml-reporting/archive/2.5.1.zip &
     cd unittest-xml-reporting-2.5.1 && \
     python setup.py install
 
+RUN apk --update add --no-cache g++
+RUN pip install pandas==1.3.3
+
 COPY rununittest /bin/rununittest
 RUN chmod u+x /bin/rununittest

--- a/worker3/Dockerfile
+++ b/worker3/Dockerfile
@@ -1,9 +1,9 @@
 FROM python:3.7.3-alpine
 MAINTAINER Franco Leonardo Bulgarelli
 
-RUN wget https://github.com/xmlrunner/unittest-xml-reporting/archive/master.zip && \
-    unzip master.zip && \
-    cd unittest-xml-reporting-master && \
+RUN wget https://github.com/xmlrunner/unittest-xml-reporting/archive/2.5.1.zip && \
+    unzip 2.5.1.zip && \
+    cd unittest-xml-reporting-2.5.1 && \
     python setup.py install
 
 COPY rununittest /bin/rununittest


### PR DESCRIPTION
# :dart: Goal

To add support for pandas

# :memo: Details

I have just added pandas to the base image. However, building pandas in alpine takes a lot of time and produces too big images. This seems to be a known-issue: 

* https://stackoverflow.com/questions/49037742/why-does-it-take-ages-to-install-pandas-on-alpine-linux/49057289#49057289
* https://pythonspeed.com/articles/alpine-docker-python/

So we should probable move to ubuntu again. 

# :soon: Future work

We should also update to python `3.10`