### PR TITLE
Add support for matplotlib

### DIFF
--- a/lib/python3/metadata_hook.rb
+++ b/lib/python3/metadata_hook.rb
@@ -6,7 +6,8 @@ class Python3MetadataHook < BasePythonMetadataHook
   def libraries
     {
       pandas: '1.3.3',
-      matplotlib: '3.5.3'
+      matplotlib: '3.5.3',
+      seaborn: '0.12.0'
     }
   end
 end

--- a/lib/python3/metadata_hook.rb
+++ b/lib/python3/metadata_hook.rb
@@ -4,6 +4,9 @@ class Python3MetadataHook < BasePythonMetadataHook
   end
 
   def libraries
-    {pandas: '1.3.3'}
+    {
+      pandas: '1.3.3',
+      matplotlib: '3.5.3'
+    }
   end
 end

--- a/lib/python3_runner.rb
+++ b/lib/python3_runner.rb
@@ -3,7 +3,7 @@ require_relative './base'
 def reload_python3_runner!
   Mumukit.runner_name = 'python3'
   Mumukit.configure do |config|
-    config.docker_image = 'mumuki/mumuki-python3-worker:0.3'
+    config.docker_image = 'mumuki/mumuki-python3-worker:1.0'
     config.comment_type = Mumukit::Directives::CommentType::Ruby
     config.structured = true
     config.stateful = true

--- a/worker3/Dockerfile
+++ b/worker3/Dockerfile
@@ -7,7 +7,8 @@ RUN wget https://github.com/xmlrunner/unittest-xml-reporting/archive/2.5.1.zip &
     python setup.py install
 
 RUN pip install pandas==1.3.3 \
-                matplotlib==3.5.3
+                matplotlib==3.5.3 \
+                seaborn==0.12.0
 
 COPY rununittest /bin/rununittest
 RUN chmod u+x /bin/rununittest

--- a/worker3/Dockerfile
+++ b/worker3/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7.3-alpine
+FROM python:3.7.3
 MAINTAINER Franco Leonardo Bulgarelli
 
 RUN wget https://github.com/xmlrunner/unittest-xml-reporting/archive/2.5.1.zip && \
@@ -6,8 +6,8 @@ RUN wget https://github.com/xmlrunner/unittest-xml-reporting/archive/2.5.1.zip &
     cd unittest-xml-reporting-2.5.1 && \
     python setup.py install
 
-RUN apk --update add --no-cache g++
-RUN pip install pandas==1.3.3
+RUN pip install pandas==1.3.3 \
+                matplotlib==3.5.3
 
 COPY rununittest /bin/rununittest
 RUN chmod u+x /bin/rununittest


### PR DESCRIPTION
# :dart: Goal

To add support for `matplotlib` and `seaborn`

# :memo: Details

Base image has been changed from alpine to plain debian-based, in order to reduce build times and prevent some potential incompatibilities. See https://pythonspeed.com/articles/alpine-docker-python/ and https://stackoverflow.com/questions/49037742/why-does-it-take-ages-to-install-pandas-on-alpine-linux 

