### PR TITLE
Preserve newlines in assertion errors

### DIFF
--- a/lib/base/test_hook.rb
+++ b/lib/base/test_hook.rb
@@ -57,11 +57,18 @@ python
     failure = test_case.xpath('failure', 'error')
     error = failure.attribute('type')
     message = failure.attribute('message')
+    assertion_error_message = failure.text.split("AssertionError: ")[1]&.rstrip.try do |it|
+      if it.lines.count > 1
+        it + "\n"
+      else
+        it
+      end
+    end
 
     [
         format_test_name(test_case.attribute('name').to_s),
         error.nil? ? :passed: :failed,
-        error.nil? ? '' : "#{error}: #{message}"
+        error.nil? ? '' : "#{error}: #{assertion_error_message || message}"
     ]
   end
 
@@ -69,4 +76,3 @@ python
     name.sub('test_', '').gsub('_', ' ').capitalize
   end
 end
-

--- a/lib/base/test_hook.rb
+++ b/lib/base/test_hook.rb
@@ -57,19 +57,19 @@ python
     failure = test_case.xpath('failure', 'error')
     error = failure.attribute('type')
     message = failure.attribute('message')
-    assertion_error_message = failure.text.split("AssertionError: ")[1]&.rstrip.try do |it|
-      if it.lines.count > 1
-        it + "\n"
-      else
-        it
-      end
-    end
+    assertion_error_message = try_extract_assertion_error(failure)
 
     [
         format_test_name(test_case.attribute('name').to_s),
         error.nil? ? :passed: :failed,
         error.nil? ? '' : "#{error}: #{assertion_error_message || message}"
     ]
+  end
+
+  def try_extract_assertion_error(failure)
+    failure.text.split("AssertionError: ")[1]&.rstrip.try do |it|
+      it.lines.count > 1 ? it + "\n" : it
+    end
   end
 
   def format_test_name(name)

--- a/spec/common/spec_helper.rb
+++ b/spec/common/spec_helper.rb
@@ -2,3 +2,9 @@ require_relative './query_hook_shared_examples'
 require_relative './test_hook_shared_examples'
 require_relative './expectations_hook_shared_examples'
 require_relative './integration_shared_examples'
+
+RSpec.configure do |rspec|
+  rspec.expect_with :rspec do |c|
+    c.max_formatted_output_length = nil
+  end
+end

--- a/spec/python3/integration_spec.rb
+++ b/spec/python3/integration_spec.rb
@@ -29,6 +29,40 @@ def test_foo_returns_false(self):
                            response_type: :structured)
   end
 
+  it 'answers a valid hash when submission is not ok because of simple assertion failure' do
+    response = bridge.
+        run_tests!(test: '
+def test_x_returns_1(self):
+    self.assertEqual(x, 1)',
+                   extra: '',
+                   content: 'x = 10',
+                   expectations: []).
+        reject { |k, _v| k == :result }
+
+    expect(response).to eq(status: :failed,
+                           expectation_results: [],
+                           feedback: '',
+                           test_results: [{result: "AssertionError: 10 != 1", status: :failed, title: 'X returns 1'}],
+                           response_type: :structured)
+  end
+
+  it 'answers a valid hash when submission is not ok because of multiline assertion failure' do
+    response = bridge.
+        run_tests!(test: '
+def test_x_returns_hi(self):
+    self.assertEqual(x, "hi")',
+                   extra: '',
+                   content: 'x = "fi"',
+                   expectations: []).
+        reject { |k, _v| k == :result }
+
+    expect(response).to eq(status: :failed,
+                           expectation_results: [],
+                           feedback: '',
+                           test_results: [{result: "AssertionError: 'fi' != 'hi'\n- fi\n+ hi\n", status: :failed, title: 'X returns hi'}],
+                           response_type: :structured)
+  end
+
   it 'answers a valid hash when submission presents version-specific expectations and behaviour' do
     response = bridge.run_tests!(
         test: '

--- a/spec/python3/test_hook_spec.rb
+++ b/spec/python3/test_hook_spec.rb
@@ -20,9 +20,73 @@ def test_false_is_true(self):
   self.assertTrue(False)
 ') }
     it { expect(result[0]).to match_array [
-                                              ['Ruby is python', :failed, "AssertionError: 'ruby' != 'python' - ruby + python "],
+                                              ['Ruby is python', :failed, "AssertionError: 'ruby' != 'python'\n- ruby\n+ python\n"],
                                               ['True is true', :passed, ''],
                                               ['False is true', :failed, 'AssertionError: False is not true'],
                                           ] }
+  end
+
+
+  context 'properly displays complex string comparisons' do
+    let(:request) { struct(content: '
+def greet():
+  return "hello world"', test: '
+def test_greet_is_hello(self):
+  self.assertEqual(greet(), "hello")') }
+
+    it { expect(result[0]).to match_array [[
+      "Greet is hello",
+      :failed,
+      <<~EOM
+      AssertionError: 'hello world' != 'hello'
+      - hello world
+      + hello
+      EOM
+      ]] }
+  end
+
+  context 'properly displays complex list comparisons' do
+    let(:request) { struct(content: '
+def numbers():
+  return [1, 2, 5, 8]', test: '
+def test_numbers_is_a_list(self):
+  self.assertEqual(numbers(), [1, 2, 4, 5, 6, 7, 8])') }
+
+    it { expect(result[0]).to match_array [[
+      "Numbers is a list",
+      :failed,
+      <<~EOM
+      AssertionError: Lists differ: [1, 2, 5, 8] != [1, 2, 4, 5, 6, 7, 8]
+
+      First differing element 2:
+      5
+      4
+
+      Second list contains 3 additional elements.
+      First extra element 4:
+      6
+
+      - [1, 2, 5, 8]
+      + [1, 2, 4, 5, 6, 7, 8]
+      EOM
+      ]] }
+  end
+
+  context 'properly displays complex dict comparisons' do
+    let(:request) { struct(content: '
+def person():
+  return {}', test: '
+def test_person_is_a_dict(self):
+  self.assertEqual(person(), {"name":"Umi", "age":28})') }
+
+    it { expect(result[0]).to match_array [[
+      "Person is a dict",
+      :failed,
+      <<~EOM
+      AssertionError: {} != {'name': 'Umi', 'age': 28}
+      - {}
+      + {'age': 28, 'name': 'Umi'}
+      EOM
+      ]] }
   end
 end


### PR DESCRIPTION
# :dart: Goal

To prevent breaking assertion error format when it contains multiline information. 