### PR TITLE
Add support for date and datetime

### DIFF
--- a/lib/base/query_hook.rb
+++ b/lib/base/query_hook.rb
@@ -14,6 +14,7 @@ class BasePythonQueryHook < Mumukit::Templates::FileHook
     <<python
 # -*- coding: UTF-8 -*-
 import string, sys, os
+from datetime import datetime, date
 
 #{req.extra}
 #{req.content}

--- a/lib/base/test_hook.rb
+++ b/lib/base/test_hook.rb
@@ -16,6 +16,7 @@ class BasePythonTestHook < Mumukit::Templates::FileHook
 import unittest
 import xmlrunner
 import sys
+from datetime import datetime, date
 
 #{request.extra}
 #{request.content}

--- a/lib/base/test_hook.rb
+++ b/lib/base/test_hook.rb
@@ -1,5 +1,6 @@
 class BasePythonTestHook < Mumukit::Templates::FileHook
   isolated true
+  line_number_offset 8, include_extra: true
 
   def tempfile_extension
     '.py'
@@ -38,6 +39,14 @@ python
     [generate_test_results(Nokogiri::XML(xml))]
   rescue
     [output, :errored]
+  end
+
+  def line_number_reference_regexp
+    /"#{masked_tempfile_path}", line (\d+)/m
+  end
+
+  def rebuild_line_number_reference(new_line_number)
+    "\"#{masked_tempfile_path}\", line #{new_line_number}"
   end
 
   private

--- a/spec/common/integration_shared_examples.rb
+++ b/spec/common/integration_shared_examples.rb
@@ -69,7 +69,7 @@ def test_foo_returns_false(self):
                            feedback: '',
                            test_results: [],
                            result: "Traceback (most recent call last):\n" +
-                                   "  File \"solution.py\", line 9, in <module>\n" +
+                                   "  File \"solution.py\", line 1, in <module>\n" +
                                    "    no#COMPILA!\"\n" +
                                    "NameError: name 'no' is not defined\n",
                            response_type: :unstructured)

--- a/spec/common/integration_shared_examples.rb
+++ b/spec/common/integration_shared_examples.rb
@@ -69,7 +69,7 @@ def test_foo_returns_false(self):
                            feedback: '',
                            test_results: [],
                            result: "Traceback (most recent call last):\n" +
-                                   "  File \"solution.py\", line 8, in <module>\n" +
+                                   "  File \"solution.py\", line 9, in <module>\n" +
                                    "    no#COMPILA!\"\n" +
                                    "NameError: name 'no' is not defined\n",
                            response_type: :unstructured)

--- a/spec/python3/query_hook_spec.rb
+++ b/spec/python3/query_hook_spec.rb
@@ -24,6 +24,16 @@ describe Python3QueryHook do
     it { expect(result).to eq ["'foo'\n", :passed] }
   end
 
+  context 'passes when standalone query is valid and returns a date.' do
+    let(:request) { struct query: 'date(2014, 11, 20)' }
+    it { expect(result).to eq ["datetime.date(2014, 11, 20)\n", :passed] }
+  end
+
+  context 'passes when standalone query is valid and returns a datetime.' do
+    let(:request) { struct query: 'datetime(2014, 11, 20, 0, 0, 0)' }
+    it { expect(result).to eq ["datetime.datetime(2014, 11, 20, 0, 0)\n", :passed] }
+  end
+
   context 'passes when standalone query is valid and has utf8 chars.' do
     let(:request) { struct query: '"fó" + "ò"' }
     it { expect(result).to eq ["'fóò'\n", :passed] }

--- a/spec/python3/test_hook_spec.rb
+++ b/spec/python3/test_hook_spec.rb
@@ -26,6 +26,49 @@ def test_false_is_true(self):
                                           ] }
   end
 
+  context 'properly displays line numbers on compilation failure' do
+    let(:request) do
+      struct(
+        content: <<~EOF,
+        def greet()
+          return "hello world"
+        EOF
+        test: <<~EOF,
+        def test_greet_is_hello(self):
+          self.assertEqual(greet(), "hello")')
+        EOF
+        extra: extra
+      )
+    end
+
+    context 'with extra' do
+      let(:extra) do
+        "x = 42\n"
+      end
+
+      it do
+        expect(result[0]).to eq(
+          "  File \"solution.py\", line 1\n"\
+          "    def greet()\n"\
+          "              ^\n"\
+          "SyntaxError: invalid syntax\n")
+      end
+    end
+
+    context 'without extra' do
+      let(:extra) do
+        nil
+      end
+
+      it do
+        expect(result[0]).to eq(
+          "  File \"solution.py\", line 1\n"\
+          "    def greet()\n"\
+          "              ^\n"\
+          "SyntaxError: invalid syntax\n")
+      end
+    end
+  end
 
   context 'properly displays complex string comparisons' do
     let(:request) { struct(content: '


### PR DESCRIPTION
# :dart: Goal

To allow `date` and `datetime` be used without requiring imports. 

# :memo: Details

During the process, line numbers offset has been corrected. 
