### PR TITLE
Add support for escapes in unittest test names

### DIFF
--- a/lib/base/test_hook.rb
+++ b/lib/base/test_hook.rb
@@ -83,6 +83,15 @@ python
   end
 
   def format_test_name(name)
-    name.sub('test_', '').gsub('_', ' ').capitalize
+    name
+      .sub('test_', '')
+      .gsub('__PL__', '(')
+      .gsub('__PR__', ')')
+      .gsub('__DT__', '.')
+      .gsub('__CM__', ',')
+      .gsub('__QT__', '\'')
+      .gsub('__DQ__', '"')
+      .gsub('_', ' ')
+      .capitalize
   end
 end

--- a/spec/common/test_hook_shared_examples.rb
+++ b/spec/common/test_hook_shared_examples.rb
@@ -8,6 +8,15 @@ def test_true_is_true(self):
     it { expect(result[0]).to match_array [['True is true', :passed, '']] }
   end
 
+  context 'formats special words' do
+    let(:request) { struct(content: '
+def foo():
+  return 4', test: '
+def test_foo__PL__5__DT__1__CM____QT__hello__QT____CM____DQ__bar__DQ____PR__(self):
+  self.assertTrue(True)') }
+    it { expect(result[0]).to match_array [['Foo(5.1,\'hello\',"bar")', :passed, '']] }
+  end
+
   context 'fails when test fails' do
     let(:request) { struct(content: '
 def foo():


### PR DESCRIPTION
# :dart: Goal

To allow some special tokens to be used as escapes in tests names: 

* `__PL__`: `(`
* `__PR__`: `)`
* `__DT__`: `.`
* `__CM__`: `,`
* `__QT__`: `'`
* `__DQ__`: `"`


For example: 

```python

  def test_1__DT__5_is_1__DT__5(self):
    self.assertEqual(1.5, 1.5)
```